### PR TITLE
Add environment getters and document required keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_FUNCTIONS_URL=https://your-project.functions.supabase.co
 # Temporary session token issued during local dev (leave blank to rely on auth flow)
 SUPABASE_SESSION_TOKEN=
+# Public anon key used for Supabase REST access when required by the client
+SUPABASE_ANON_KEY=
+
+# REST endpoint returning the daily challenge payload from Supabase
+SUPABASE_DAILY_CHALLENGE_ENDPOINT=
 
 # Ephemeral provider session tokens (issued by edge functions; leave empty locally)
 OPENAI_SESSION_TOKEN=

--- a/lib/core/config/environment.dart
+++ b/lib/core/config/environment.dart
@@ -44,4 +44,26 @@ class Environment {
 
     return fallback ?? '';
   }
+
+  /// Supabase session token used to authenticate requests during development.
+  static String get supabaseSessionToken =>
+      _read('SUPABASE_SESSION_TOKEN');
+
+  /// Base URL for Supabase edge functions. Required for proxy requests.
+  static String get supabaseFunctionsUrl =>
+      _read('SUPABASE_FUNCTIONS_URL');
+
+  /// Base URL for OpenAI requests. Defaults to the public API endpoint.
+  static String get openAiBaseUrl =>
+      _read('OPENAI_BASE_URL', fallback: 'https://api.openai.com/v1');
+
+  /// REST endpoint for fetching the daily challenge from Supabase.
+  static String get supabaseDailyChallengeEndpoint =>
+      _read('SUPABASE_DAILY_CHALLENGE_ENDPOINT');
+
+  /// Public Supabase anon key when required by client integrations.
+  static String? get supabaseAnonKeyOrNull {
+    final value = _read('SUPABASE_ANON_KEY');
+    return value.isEmpty ? null : value;
+  }
 }


### PR DESCRIPTION
## Summary
- expose strongly-typed environment getters with sensible defaults for all referenced keys
- document Supabase anon key and daily challenge endpoint variables in the example env file

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d773a517e0832d89d6cc06520c3e41