### PR TITLE
Add root SortBlissApp widget to bootstrap application

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await Environment.bootstrap();
-  
+
   await AchievementsTrackerService.instance.ensureInitialized();
   await PlayerProfileService.instance.ensureInitialized();
 
@@ -21,14 +21,38 @@ void main() async {
     if (!_hasShownError) {
       _hasShownError = true;
       // Reset flag after 3 seconds to allow error widget on new screens
-      Future.delayed(Duration(seconds: 5), () {
+      Future.delayed(const Duration(seconds: 5), () {
         _hasShownError = false;
       });
       return CustomErrorWidget(
         errorDetails: details,
       );
     }
-    return SizedBox.shrink();
+    return const SizedBox.shrink();
   };
   // 🚨 CRITICAL: Device orientation lock - DO NOT REMOVE
   await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+
+  runApp(const SortBlissApp());
+}
+
+class SortBlissApp extends StatelessWidget {
+  const SortBlissApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Sizer(
+      builder: (context, orientation, deviceType) {
+        return MaterialApp(
+          title: 'SortBliss',
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: ThemeMode.system,
+          initialRoute: AppRoutes.initial,
+          routes: AppRoutes.routes,
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a SortBlissApp root widget that wraps MaterialApp with project routes and theming
- call runApp after the orientation lock so the Flutter application can boot correctly

## Testing
- not run (flutter analyze unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d773a57e50832da8f1a89ce55496ac