### PR TITLE
Fix play button navigation route

### DIFF
--- a/lib/presentation/main_menu/main_menu.dart
+++ b/lib/presentation/main_menu/main_menu.dart
@@ -225,7 +225,10 @@ class _MainMenuState extends State<MainMenu>
                           margin: EdgeInsets.only(bottom: 4.h),
                           child: PlayButtonWidget(
                             onPressed: () {
-                              Navigator.pushNamed(context, '/gameplay');
+                              Navigator.pushNamed(
+                                context,
+                                AppRoutes.gameplay,
+                              );
                             },
                           ),
                         ),

--- a/test/presentation/main_menu/main_menu_navigation_test.dart
+++ b/test/presentation/main_menu/main_menu_navigation_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sizer/sizer.dart';
+
+import 'package:sortbliss/presentation/main_menu/main_menu.dart';
+import 'package:sortbliss/routes/app_routes.dart';
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  final List<Route<dynamic>> pushedRoutes = <Route<dynamic>>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    pushedRoutes.add(route);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'tapping the play button navigates to gameplay',
+    (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object?>{});
+
+      final _RecordingNavigatorObserver observer =
+          _RecordingNavigatorObserver();
+
+      await tester.pumpWidget(
+        Sizer(
+          builder: (BuildContext context, Orientation orientation,
+              DeviceType deviceType) {
+            return MaterialApp(
+              routes: AppRoutes.routes,
+              navigatorObservers: <NavigatorObserver>[observer],
+              home: const MainMenu(),
+            );
+          },
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final Finder playButtonFinder = find.text('PLAY');
+      expect(playButtonFinder, findsOneWidget);
+
+      await tester.tap(playButtonFinder);
+      await tester.pumpAndSettle();
+
+      expect(
+        observer.pushedRoutes.map((Route<dynamic> route) => route.settings.name),
+        contains(AppRoutes.gameplay),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- update the main menu play button to navigate using `AppRoutes.gameplay` so it matches the registered routes
- add a widget test that pumps the main menu and verifies tapping the play button pushes the gameplay route

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e34046894c832d8567c92526894ac3