### PR TITLE
Add storefront screen and route

### DIFF
--- a/lib/presentation/storefront/storefront_screen.dart
+++ b/lib/presentation/storefront/storefront_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+/// Displays available premium content and purchase options for SortBliss.
+class StorefrontScreen extends StatelessWidget {
+  const StorefrontScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Storefront'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Unlock premium audio sets and seasonal themes to personalize your experience.',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: ListView(
+                  children: const [
+                    _StorefrontTile(
+                      icon: Icons.music_note,
+                      title: 'Ambient soundscapes',
+                      subtitle:
+                          'Immerse yourself with adaptive audio tailored to each puzzle mood.',
+                    ),
+                    _StorefrontTile(
+                      icon: Icons.color_lens,
+                      title: 'Seasonal themes',
+                      subtitle:
+                          'Refresh SortBliss with limited-time palettes inspired by the calendar.',
+                    ),
+                    _StorefrontTile(
+                      icon: Icons.bolt,
+                      title: 'Productivity boosts',
+                      subtitle:
+                          'Reduce cooldown timers and access expert-ranked puzzle variants.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Purchases are not yet available.'),
+                      ),
+                    );
+                  },
+                  child: const Text('Coming soon'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StorefrontTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  const _StorefrontTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: colorScheme.primaryContainer,
+          child: Icon(icon, color: colorScheme.onPrimaryContainer),
+        ),
+        title: Text(title),
+        subtitle: Text(subtitle),
+      ),
+    );
+  }
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -6,6 +6,7 @@ import '../presentation/level_complete_screen/level_complete_screen.dart';
 import '../presentation/main_menu/main_menu.dart';
 import '../presentation/settings/settings_screen.dart';
 import '../presentation/splash_screen/splash_screen.dart';
+import '../presentation/storefront/storefront_screen.dart';
 
 class AppRoutes {
   // TODO: Add your routes here
@@ -17,6 +18,7 @@ class AppRoutes {
   static const String dailyChallenge = '/daily-challenge';
   static const String achievements = '/achievements';
   static const String settings = '/settings';
+  static const String storefront = '/storefront';
 
   static Map<String, WidgetBuilder> routes = {
     initial: (context) => const SplashScreen(),
@@ -58,6 +60,7 @@ class AppRoutes {
       );
     },
     settings: (context) => const SettingsScreen(),
+    storefront: (context) => const StorefrontScreen(),
     dailyChallenge: (context) {
       final args = ModalRoute.of(context)?.settings.arguments;
       if (args is DailyChallengeScreenArgs) {

--- a/test/presentation/storefront/storefront_route_navigation_test.dart
+++ b/test/presentation/storefront/storefront_route_navigation_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sortbliss/routes/app_routes.dart';
+
+void main() {
+  testWidgets('navigating to storefront shows storefront screen', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        routes: AppRoutes.routes,
+        initialRoute: AppRoutes.storefront,
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Storefront'), findsOneWidget);
+    expect(
+      find.text(
+        'Unlock premium audio sets and seasonal themes to personalize your experience.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Coming soon'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated `StorefrontScreen` with placeholder premium content messaging
- register the storefront path in `AppRoutes` so it can be navigated like other screens
- cover the new navigation flow with a widget test for the storefront route

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the execution environment)*
- flutter test *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e34048a588832dbb8ba64fb27192bc