### PR TITLE
Fix action button icon usage and add widget test

### DIFF
--- a/lib/presentation/level_complete_screen/widgets/action_buttons_widget.dart
+++ b/lib/presentation/level_complete_screen/widgets/action_buttons_widget.dart
@@ -123,7 +123,7 @@ class _ActionButtonsWidgetState extends State<ActionButtonsWidget>
   Widget _buildSecondaryButton({
     required String text,
     required VoidCallback onPressed,
-    required IconData icon,
+    required String iconName,
   }) {
     return SizedBox(
       width: double.infinity,
@@ -131,7 +131,7 @@ class _ActionButtonsWidgetState extends State<ActionButtonsWidget>
       child: OutlinedButton.icon(
         onPressed: onPressed,
         icon: CustomIconWidget(
-          iconName: icon.toString().split('.').last,
+          iconName: iconName,
           color: AppTheme.lightTheme.colorScheme.primary,
           size: 4.w,
         ),
@@ -229,7 +229,7 @@ class _ActionButtonsWidgetState extends State<ActionButtonsWidget>
                   child: _buildSecondaryButton(
                     text: 'Replay',
                     onPressed: widget.onReplayLevel,
-                    icon: Icons.replay,
+                    iconName: 'replay',
                   ),
                 ),
                 SizedBox(width: 3.w),
@@ -237,7 +237,7 @@ class _ActionButtonsWidgetState extends State<ActionButtonsWidget>
                   child: _buildSecondaryButton(
                     text: 'Share',
                     onPressed: widget.onShareScore,
-                    icon: Icons.share,
+                    iconName: 'share',
                   ),
                 ),
               ],

--- a/test/presentation/level_complete_screen/action_buttons_widget_test.dart
+++ b/test/presentation/level_complete_screen/action_buttons_widget_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sizer/sizer.dart';
+
+import 'package:sortbliss/presentation/level_complete_screen/widgets/action_buttons_widget.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget _buildTestWidget() {
+    return Sizer(
+      builder: (context, orientation, deviceType) {
+        return MaterialApp(
+          home: Scaffold(
+            body: ActionButtonsWidget(
+              onNextLevel: () {},
+              onReplayLevel: () {},
+              onShareScore: () {},
+              showAdButton: false,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  testWidgets('renders replay and share icons for secondary buttons', (tester) async {
+    await tester.pumpWidget(_buildTestWidget());
+    await tester.pump();
+
+    expect(find.byIcon(Icons.replay), findsOneWidget);
+    expect(find.byIcon(Icons.share), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- pass explicit icon identifiers to the level complete action buttons
- add a widget test to confirm the replay and share buttons render the correct icons

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3404b6e80832d930d166320e4f708