### PR TITLE
chore: move beta plugins to stable releases

### DIFF
--- a/docs/dependency_review.md
+++ b/docs/dependency_review.md
@@ -1,0 +1,22 @@
+# Dependency Review (Speech recognition & secure storage)
+
+## Packages audited
+- `speech_to_text`
+- `flutter_secure_storage`
+- `rive`
+
+## Summary
+- Updated `speech_to_text` to the latest stable major available to avoid relying on pre-release APIs.
+- Reverted `flutter_secure_storage` to the stable `9.x` line that matches the current production plugin channel.
+- Downgraded `rive` to the most recent stable `0.13.x` runtime while the repository remains on stable Flutter tooling.
+
+## Follow-up
+Because the execution environment blocks outbound network traffic, I could not download the official CHANGELOG files or run `flutter pub upgrade` / `flutter analyze` / `flutter test`. Run the commands below in an environment with Flutter SDK access to verify:
+
+```sh
+flutter pub upgrade
+flutter analyze
+flutter test
+```
+
+If any command fails, capture the console output and re-evaluate whether a pre-release build is required.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,15 +25,15 @@ dependencies:
   audioplayers: ^6.5.1       # Comprehensive audio system with background music and sound effects
   vibration: ^3.1.4          # Tactile haptic feedback on user interactions
   flutter_animate: ^4.5.2    # Advanced animation effects and builders with customizable, unified API
-  rive: ^0.14.0-dev.8        # Professional animation runtime and interactive animations
+  rive: ^0.13.18             # Professional animation runtime and interactive animations
   flutter_tilt: ^3.3.2       # Tilt parallax hover effects with light, shadow effects, and gyroscope sensor support
   sensors_plus: ^7.0.0       # Accessing accelerometer, gyroscope, and magnetometer sensors for tilt controls
-  speech_to_text: ^7.4.0-beta.6 # Voice command recognition and accessibility features
+  speech_to_text: ^7.0.0     # Voice command recognition and accessibility features
   flutter_tts: ^4.2.3        # Text-to-speech functionality supporting iOS, macOS, Android, Web, and Windows
   camera: ^0.11.2            # Camera access and gesture recognition capabilities
   vector_math: ^2.1.4        # Advanced 3D mathematical operations and transformations
   collection: ^1.19.1        # Enhanced collections and utilities for data structure operations
-  flutter_secure_storage: ^10.0.0-beta.4 # Secure storage of sensitive user data
+  flutter_secure_storage: ^9.2.2 # Secure storage of sensitive user data
   in_app_purchase: ^3.2.0
   google_mobile_ads: ^5.2.0
   in_app_review: ^2.0.8


### PR DESCRIPTION
## Summary
- replace beta versions of speech_to_text and flutter_secure_storage with their latest stable releases
- align the rive runtime with the current 0.13.x stable channel
- document the dependency review outcome and follow-up verification steps

## Testing
- flutter pub upgrade *(fails: Flutter SDK is not available in this environment)*
- flutter analyze *(fails: Flutter SDK is not available in this environment)*
- flutter test *(fails: Flutter SDK is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3404c2148832d81b2a3f0f700988f