### PR TITLE
Adjust daily challenge dispose cleanup

### DIFF
--- a/lib/core/services/daily_challenge_service.dart
+++ b/lib/core/services/daily_challenge_service.dart
@@ -425,7 +425,8 @@ class DailyChallengeService {
     }
     _isDisposed = true;
     await _challengeController.close();
-    await _httpClient.close(force: true);
+    _httpClient.close(force: true);
+    return;
   }
 
   Future<DailyChallengePayload?> _fetchDailyChallengeFromSupabase() async {


### PR DESCRIPTION
## Summary
- stop awaiting the HTTP client close during daily challenge disposal while keeping the controller close awaited
- explicitly return after synchronous cleanup to retain the Future<void> signature

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35b154ae8832d8034368b24bb9426