### PR TITLE
Configure Supabase daily challenge service and add test

### DIFF
--- a/lib/core/services/daily_challenge_service.dart
+++ b/lib/core/services/daily_challenge_service.dart
@@ -5,6 +5,18 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 
+/// Error thrown when Supabase configuration is missing for the
+/// [DailyChallengeService].
+class MissingDailyChallengeConfigurationException implements Exception {
+  const MissingDailyChallengeConfigurationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() =>
+      'MissingDailyChallengeConfigurationException: $message';
+}
+
 /// Lightweight representation of a reward attached to a daily challenge or
 /// weekly event.
 class ChallengeReward {
@@ -322,6 +334,10 @@ class DailyChallengeService {
         stackTrace: stackTrace,
         name: 'DailyChallengeService',
       );
+
+      if (error is MissingDailyChallengeConfigurationException) {
+        throw error;
+      }
     }
 
     if (payload == null) {
@@ -361,6 +377,10 @@ class DailyChallengeService {
         stackTrace: stackTrace,
         name: 'DailyChallengeService',
       );
+
+      if (error is MissingDailyChallengeConfigurationException) {
+        throw error;
+      }
     }
 
     schedule ??= await _loadRemoteConfigWeeklyEvents();
@@ -429,9 +449,7 @@ class DailyChallengeService {
   }
 
   Future<DailyChallengePayload?> _fetchDailyChallengeFromSupabase() async {
-    if (supabaseRestEndpoint == null || supabaseRestEndpoint!.isEmpty) {
-      return null;
-    }
+    _ensureSupabaseConfiguration();
 
     final response = await _httpClient.get<List<dynamic>>(
       supabaseRestEndpoint!,
@@ -467,9 +485,7 @@ class DailyChallengeService {
   }
 
   Future<WeeklyEventSchedule?> _fetchWeeklyEventsFromSupabase() async {
-    if (supabaseRestEndpoint == null || supabaseRestEndpoint!.isEmpty) {
-      return null;
-    }
+    _ensureSupabaseConfiguration();
 
     final uri = Uri.parse(supabaseRestEndpoint!);
     final path = uri.replace(path: '${uri.path}/weekly_events').toString();
@@ -693,6 +709,23 @@ class DailyChallengeService {
       case DateTime.sunday:
       default:
         return 'Serenity';
+    }
+  }
+
+  void _ensureSupabaseConfiguration() {
+    final missing = <String>[];
+    if (supabaseRestEndpoint == null || supabaseRestEndpoint!.isEmpty) {
+      missing.add('SUPABASE_DAILY_CHALLENGE_ENDPOINT');
+    }
+    if (supabaseAnonKey == null || supabaseAnonKey!.isEmpty) {
+      missing.add('SUPABASE_ANON_KEY');
+    }
+
+    if (missing.isNotEmpty) {
+      throw MissingDailyChallengeConfigurationException(
+        'Missing configuration: ${missing.join(', ')}. '
+        'Provide the required Supabase values before fetching remote data.',
+      );
     }
   }
 }

--- a/lib/presentation/main_menu/main_menu.dart
+++ b/lib/presentation/main_menu/main_menu.dart
@@ -4,6 +4,7 @@ import 'package:in_app_review/in_app_review.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:sizer/sizer.dart';
 import '../../core/app_export.dart';
+import '../../core/config/environment.dart';
 import '../../core/services/daily_challenge_service.dart';
 import '../../core/services/player_profile_service.dart';
 import '../../theme/app_theme.dart';
@@ -60,7 +61,10 @@ class _MainMenuState extends State<MainMenu>
       });
     }));
 
-    _dailyChallengeService = DailyChallengeService();
+    _dailyChallengeService = DailyChallengeService(
+      supabaseRestEndpoint: Environment.supabaseDailyChallengeEndpoint,
+      supabaseAnonKey: Environment.supabaseAnonKeyOrNull,
+    );
 
     _fadeController = AnimationController(
       duration: const Duration(milliseconds: 1500),

--- a/test/core/services/daily_challenge_service_test.dart
+++ b/test/core/services/daily_challenge_service_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sortbliss/core/services/daily_challenge_service.dart';
+
+void main() {
+  group('DailyChallengeService', () {
+    test('fetches challenge data from configured Supabase endpoint', () async {
+      final resetAt =
+          DateTime.now().toUtc().add(const Duration(hours: 2)).toIso8601String();
+      final responsePayload = [
+        {
+          'id': 'challenge-123',
+          'title': 'Test Challenge',
+          'description': 'Complete the puzzle fast',
+          'target_stars': 5,
+          'current_stars': 2,
+          'reset_at': resetAt,
+          'rewards': [
+            {
+              'type': 'coins',
+              'amount': 100,
+              'is_exclusive': false,
+            }
+          ],
+          'level_config': {
+            'layout_id': 'layout-1',
+            'difficulty': 3,
+            'modifiers': ['double_points'],
+            'metadata': <String, dynamic>{},
+          },
+          'rewards_claimed': false,
+        }
+      ];
+
+      final adapter = _RecordingAdapter(
+        responseBody: ResponseBody.fromString(
+          jsonEncode(responsePayload),
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['application/json'],
+          },
+        ),
+      );
+
+      final dio = Dio()..httpClientAdapter = adapter;
+
+      final service = DailyChallengeService(
+        httpClient: dio,
+        supabaseRestEndpoint:
+            'https://example.supabase.co/rest/v1/daily_challenge',
+        supabaseAnonKey: 'anon-key',
+      );
+
+      addTearDown(() async {
+        await service.dispose();
+      });
+
+      final result = await service.loadDailyChallenge(forceRefresh: true);
+
+      expect(adapter.lastRequest, isNotNull);
+      expect(
+        adapter.lastRequest!.uri.toString(),
+        'https://example.supabase.co/rest/v1/daily_challenge',
+      );
+      expect(adapter.lastRequest!.headers['apikey'], 'anon-key');
+      expect(result.id, 'challenge-123');
+      expect(result.rewards, isNotEmpty);
+    });
+  });
+}
+
+class _RecordingAdapter extends HttpClientAdapter {
+  _RecordingAdapter({required this.responseBody});
+
+  final ResponseBody responseBody;
+  RequestOptions? lastRequest;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastRequest = options;
+    return responseBody;
+  }
+}


### PR DESCRIPTION
## Summary
- pass Supabase configuration from Environment into the MainMenu DailyChallengeService
- throw an explicit configuration error when required Supabase values are missing
- add a Dio-backed test that verifies the configured endpoint is invoked when values are present

## Testing
- flutter test test/core/services/daily_challenge_service_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e35b16d788832dade8866ce58b0d60